### PR TITLE
Fix UnboundLocalError in python installer on Windows 10

### DIFF
--- a/pioinstaller/python.py
+++ b/pioinstaller/python.py
@@ -216,6 +216,7 @@ def find_compatible_pythons(
                 error = e.output.decode()
                 log.debug(error)
             except UnicodeDecodeError:
+                error = ""
                 pass
             error = error or ""
             if "Could not find distutils module" in error:


### PR DESCRIPTION
On all up-to-date Windows 10 machines, installation currently fails due to the bundled fake python3.exe binary:

```C:\.platformio\python3\python.exe C:\.platformio\.cache\tmp\get-platformio-1.0.2.py
Installer version: 1.0.2
Platform: Windows-10
Python version: 3.9.2 (tags/v3.9.2:1a79785, Feb 19 2021, 13:44:55) [MSC v.1928 64 bit (AMD64)]
Python path: C:\.platformio\python3\python.exe
Creating a virtual environment at C:\.platformio\penv
Traceback (most recent call last):
  File "C:\.platformio\.cache\tmp\.piocore-installer-681pw754\tmp21j9w4p7\pioinstaller.zip\pioinstaller\python.py", line 199, in find_compatible_pythons
  File "C:\.platformio\python3\lib\subprocess.py", line 424, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "C:\.platformio\python3\lib\subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['C:\\Users\\user\\AppData\\Local\\Microsoft\\WindowsApps\\python3.exe', 'C:\\.platformio\\.cache\\tmp\\get-platformio-1.0.2.py', '--no-shutdown-piohome', 'check', 'python']' returned non-zero exit status 9009.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\.platformio\.cache\tmp\get-platformio-1.0.2.py", line 69, in <module>
    main()
  File "C:\.platformio\.cache\tmp\get-platformio-1.0.2.py", line 61, in main
    bootstrap()
  File "C:\.platformio\.cache\tmp\get-platformio-1.0.2.py", line 47, in bootstrap
    pioinstaller.__main__.main()
  File "C:\.platformio\.cache\tmp\.piocore-installer-681pw754\tmp21j9w4p7\pioinstaller.zip\pioinstaller\__main__.py", line 131, in main
  File "C:\.platformio\.cache\tmp\.piocore-installer-681pw754\tmp21j9w4p7\pioinstaller.zip\click\core.py", line 829, in __call__
  File "C:\.platformio\.cache\tmp\.piocore-installer-681pw754\tmp21j9w4p7\pioinstaller.zip\click\core.py", line 782, in main
  File "C:\.platformio\.cache\tmp\.piocore-installer-681pw754\tmp21j9w4p7\pioinstaller.zip\click\core.py", line 1236, in invoke
  File "C:\.platformio\.cache\tmp\.piocore-installer-681pw754\tmp21j9w4p7\pioinstaller.zip\click\core.py", line 1066, in invoke
  File "C:\.platformio\.cache\tmp\.piocore-installer-681pw754\tmp21j9w4p7\pioinstaller.zip\click\core.py", line 610, in invoke
  File "C:\.platformio\.cache\tmp\.piocore-installer-681pw754\tmp21j9w4p7\pioinstaller.zip\click\decorators.py", line 21, in new_func
  File "C:\.platformio\.cache\tmp\.piocore-installer-681pw754\tmp21j9w4p7\pioinstaller.zip\pioinstaller\__main__.py", line 61, in cli
  File "C:\.platformio\.cache\tmp\.piocore-installer-681pw754\tmp21j9w4p7\pioinstaller.zip\pioinstaller\core.py", line 67, in install_platformio_core
  File "C:\.platformio\.cache\tmp\.piocore-installer-681pw754\tmp21j9w4p7\pioinstaller.zip\pioinstaller\core.py", line 95, in _install_platformio_core
  File "C:\.platformio\.cache\tmp\.piocore-installer-681pw754\tmp21j9w4p7\pioinstaller.zip\pioinstaller\penv.py", line 52, in create_core_penv
  File "C:\.platformio\.cache\tmp\.piocore-installer-681pw754\tmp21j9w4p7\pioinstaller.zip\pioinstaller\python.py", line 220, in find_compatible_pythons
UnboundLocalError: local variable 'error' referenced before assignment
```

This PR tries to fix it. I don't know how to test it, since the `get-platformio-1.0.2.py` script downloads fresh installer copy on each run.